### PR TITLE
Handle type-only imports/exports for TS 3.8

### DIFF
--- a/src/format/compose/index.ts
+++ b/src/format/compose/index.ts
@@ -39,6 +39,7 @@ export function composeComments(comments: NodeComment[] | undefined, { nl }: Com
 
 export function composeNodeAsNames(
   verb: string,
+  isTypeOnly: boolean,
   defaultName: string | undefined,
   names: NameBinding[] | undefined,
   from: string | undefined,
@@ -46,20 +47,36 @@ export function composeNodeAsNames(
   config: ComposeConfig,
 ) {
   const { maxLength } = config;
-  const { text, canWrap } = composeNodeAsNamesImpl(verb, defaultName, names, from, config, false);
+  const { text, canWrap } = composeNodeAsNamesImpl(
+    verb,
+    isTypeOnly,
+    defaultName,
+    names,
+    from,
+    config,
+    false,
+  );
   if (maxLength >= text.length + extraLength || !canWrap) return text;
-  return composeNodeAsNamesImpl(verb, defaultName, names, from, config, true).text;
+  return composeNodeAsNamesImpl(verb, isTypeOnly, defaultName, names, from, config, true).text;
 }
 
 function composeNodeAsNamesImpl(
   verb: string,
+  isTypeOnly: boolean,
   defaultName: string | undefined,
   names: NameBinding[] | undefined,
   from: string | undefined,
   config: ComposeConfig,
   forceWrap: boolean,
 ) {
-  const { text: t, canWrap } = composeNames(verb, !!defaultName, names, config, forceWrap);
+  const { text: t, canWrap } = composeNames(
+    verb,
+    isTypeOnly,
+    !!defaultName,
+    names,
+    config,
+    forceWrap,
+  );
   const all = [defaultName, t].filter(s => !!s).join(', ');
   const text = [verb, all, from].filter(s => !!s).join(' ');
   return { text, canWrap };
@@ -67,6 +84,7 @@ function composeNodeAsNamesImpl(
 
 function composeNames(
   verb: string,
+  isTypeOnly: boolean,
   hasDefault: boolean,
   names: NameBinding[] | undefined,
   config: ComposeConfig,

--- a/src/format/parser/ExportNode.ts
+++ b/src/format/parser/ExportNode.ts
@@ -13,6 +13,7 @@ import Statement, { StatementArgs } from './Statement';
 
 export default class ExportNode extends Statement {
   private readonly moduleIdentifier_?: string;
+  private readonly isTypeOnly: boolean;
   names: NameBinding[];
 
   static fromDecl(node: ExportDeclaration, args: StatementArgs) {
@@ -23,16 +24,18 @@ export default class ExportNode extends Statement {
       .map(getNameBinding);
     if (moduleSpecifier && moduleSpecifier.kind !== SyntaxKind.StringLiteral) return undefined;
     const moduleIdentifier = moduleSpecifier && (moduleSpecifier as StringLiteral).text;
-    return new ExportNode(moduleIdentifier, names, args);
+    return new ExportNode(moduleIdentifier, names, args, node.isTypeOnly);
   }
 
   private constructor(
     moduleIdentifier: string | undefined,
     names: NameBinding[],
     args: StatementArgs,
+    isTypeOnly: boolean,
   ) {
     super(args);
     this.moduleIdentifier_ = moduleIdentifier && normalizePath(moduleIdentifier);
+    this.isTypeOnly = isTypeOnly;
     this.names = names;
   }
 
@@ -67,6 +70,16 @@ export default class ExportNode extends Statement {
     const path = this.moduleIdentifier_;
     const from = path ? 'from ' + quote(path) : undefined;
     const extraLength = commentLength + semi.length;
-    return composeNodeAsNames('export', undefined, this.names, from, extraLength, config) + semi;
+    return (
+      composeNodeAsNames(
+        'export',
+        this.isTypeOnly,
+        undefined,
+        this.names,
+        from,
+        extraLength,
+        config,
+      ) + semi
+    );
   }
 }

--- a/src/format/parser/ExportNode.ts
+++ b/src/format/parser/ExportNode.ts
@@ -13,7 +13,7 @@ import Statement, { StatementArgs } from './Statement';
 
 export default class ExportNode extends Statement {
   private readonly moduleIdentifier_?: string;
-  private readonly isTypeOnly: boolean;
+  private readonly isTypeOnly_: boolean;
   names: NameBinding[];
 
   static fromDecl(node: ExportDeclaration, args: StatementArgs) {
@@ -35,7 +35,7 @@ export default class ExportNode extends Statement {
   ) {
     super(args);
     this.moduleIdentifier_ = moduleIdentifier && normalizePath(moduleIdentifier);
-    this.isTypeOnly = isTypeOnly;
+    this.isTypeOnly_ = isTypeOnly;
     this.names = names;
   }
 
@@ -73,7 +73,7 @@ export default class ExportNode extends Statement {
     return (
       composeNodeAsNames(
         'export',
-        this.isTypeOnly,
+        this.isTypeOnly_,
         undefined,
         this.names,
         from,

--- a/src/format/parser/ImportNode.ts
+++ b/src/format/parser/ImportNode.ts
@@ -75,6 +75,10 @@ export default class ImportNode extends Statement {
     return this.binding_;
   }
 
+  get isTypeOnly() {
+    return (this.node_ as ImportDeclaration).importClause?.isTypeOnly ?? false;
+  }
+
   allNames() {
     const r: string[] = [];
     if (this.defaultName_) r.push(this.defaultName_);
@@ -253,6 +257,7 @@ export default class ImportNode extends Statement {
     if (this.binding_?.type === 'named')
       return composeNodeAsNames(
         'import',
+        this.isTypeOnly,
         this.defaultName_,
         this.binding_.names,
         from,

--- a/src/format/parser/ImportNode.ts
+++ b/src/format/parser/ImportNode.ts
@@ -78,10 +78,6 @@ export default class ImportNode extends Statement {
     return this.binding_;
   }
 
-  get isTypeOnly() {
-    return (this.node_ as ImportDeclaration).importClause?.isTypeOnly ?? false;
-  }
-
   allNames() {
     const r: string[] = [];
     if (this.defaultName_) r.push(this.defaultName_);

--- a/src/format/parser/ImportNode.ts
+++ b/src/format/parser/ImportNode.ts
@@ -28,6 +28,7 @@ export default class ImportNode extends Statement {
 
   readonly moduleIdentifier: string;
   readonly isScript: boolean;
+  private readonly isTypeOnly_: boolean;
   private defaultName_?: string;
   private binding_?: Binding;
 
@@ -36,8 +37,8 @@ export default class ImportNode extends Statement {
     if (!moduleSpecifier || moduleSpecifier.kind !== SyntaxKind.StringLiteral) return undefined;
     const moduleIdentifier = (moduleSpecifier as StringLiteral).text;
     if (!moduleIdentifier.trim()) return undefined;
-    const { defaultName, binding, isScript } = getDefaultAndBinding(importClause);
-    return new ImportNode(node, moduleIdentifier, args, defaultName, binding, isScript);
+    const { defaultName, binding, isScript, isTypeOnly } = getDefaultAndBinding(importClause);
+    return new ImportNode(node, moduleIdentifier, args, defaultName, binding, isScript, isTypeOnly);
   }
 
   static fromEqDecl(node: ImportEqualsDeclaration, args: StatementArgs) {
@@ -58,6 +59,7 @@ export default class ImportNode extends Statement {
     defaultName?: string,
     binding?: Binding,
     isScript = false,
+    isTypeOnly = false,
   ) {
     super(args);
     this.node_ = node;
@@ -65,6 +67,7 @@ export default class ImportNode extends Statement {
     this.defaultName_ = defaultName;
     this.binding_ = binding;
     this.isScript = isScript;
+    this.isTypeOnly_ = isTypeOnly;
   }
 
   get defaultName() {
@@ -114,36 +117,38 @@ export default class ImportNode extends Statement {
     }
   }
 
-  compose(config: ComposeConfig) {
-    const { leadingText, trailingText, tailingLength } = this.composeComments(config);
-    const importText = this.composeImport(tailingLength, config);
-    return leadingText + importText + trailingText;
-  }
-
   /**
    * @returns true if `node` is fully merged to `this`;
    *          false if `node` still has names or comments thus can't be ignored.
    */
   merge(node: ImportNode) {
-    const { moduleIdentifier, node_ } = node;
+    const { isTypeOnly_: t } = this;
     if (
-      this.moduleIdentifier !== moduleIdentifier ||
-      this.node_.kind !== node_.kind ||
+      this.moduleIdentifier !== node.moduleIdentifier ||
+      this.node_.kind !== node.node_.kind ||
+      t !== node.isTypeOnly_ ||
       !this.canMergeComments(node)
     )
       return false;
     this.removeBindingDefault(node.defaultName_);
     node.removeBindingDefault(this.defaultName_);
-    const r1 = this.mergeBinding(node);
-    const r2 = this.mergeDefaultName(node);
+    const r1 = this.mergeBinding(node, !t);
+    const r2 = this.mergeDefaultName(node, !t);
     return r1 && r2 && this.mergeComments(node);
   }
 
   checkBindingDefault() {
     // `import A, {default as A} from 'x'` => `import A from 'x'`
     if (this.defaultName_) this.removeBindingDefault(this.defaultName_);
-    // `import {default as A} from 'x'` => `import A from 'x'`
-    else this.defaultName_ = this.pickBindingDefault();
+    // `import {default as A, B} from 'x'` => `import A, {B} from 'x'`
+    // `import type {default as A} from 'x'` => `import type A from 'x'`
+    else this.defaultName_ = this.pickBindingDefault(this.isTypeOnly_);
+  }
+
+  compose(config: ComposeConfig) {
+    const { leadingText, trailingText, tailingLength } = this.composeComments(config);
+    const importText = this.composeImport(tailingLength, config);
+    return leadingText + importText + trailingText;
   }
 
   private removeBindingDefault(defaultName?: string) {
@@ -154,18 +159,25 @@ export default class ImportNode extends Statement {
     if (this.binding_.names.length < 1) this.binding_ = undefined;
   }
 
-  private pickBindingDefault() {
+  /**
+   * Find and remove 'default as X' from binding names and returns 'X'.
+   *
+   * If whenSingle is true and names array length is not 1, do nothing.
+   */
+  private pickBindingDefault(whenSingle = false) {
     if (this.binding_?.type !== 'named') return undefined;
+    if (whenSingle && this.binding_.names.length > 1) return undefined;
     const name = this.binding_.names.find(a => a.propertyName === 'default')?.aliasName;
     this.removeBindingDefault(name);
     return name;
   }
 
-  private mergeBinding(node: ImportNode) {
+  private mergeBinding(node: ImportNode, takeOver: boolean) {
     const { binding_: b1 } = this;
     const { binding_: b2 } = node;
     if (!b2) return true;
     else if (!b1) {
+      if (!takeOver) return false;
       this.binding_ = b2;
       node.binding_ = undefined;
       return true;
@@ -181,10 +193,13 @@ export default class ImportNode extends Statement {
     return true;
   }
 
-  private mergeDefaultName(node: ImportNode) {
+  private mergeDefaultName(node: ImportNode, takeOver: boolean) {
     if (this.defaultName_ && node.defaultName_ && this.defaultName_ !== node.defaultName_)
       return false;
-    if (!this.defaultName_) this.defaultName_ = node.defaultName_;
+    if (!this.defaultName_) {
+      if (!takeOver) return !node.defaultName_;
+      this.defaultName_ = node.defaultName_;
+    }
     node.defaultName_ = undefined;
     return true;
   }
@@ -208,7 +223,7 @@ export default class ImportNode extends Statement {
     assertNonNull(name);
     const parts = [`${name} =`];
     const from = `require(${quote(path)})`;
-    return composeNodeAsParts(parts, from, extraLength, config);
+    return composeNodeAsParts('import', parts, from, extraLength, config);
   }
 
   /**
@@ -253,11 +268,11 @@ export default class ImportNode extends Statement {
     const path = this.moduleIdentifier;
     const ending = quote(path);
     if (this.isScript) return `import ${ending}`;
+    const verb = 'import' + (this.isTypeOnly_ ? ' type' : '');
     const from = `from ${ending}`;
     if (this.binding_?.type === 'named')
       return composeNodeAsNames(
-        'import',
-        this.isTypeOnly,
+        verb,
         this.defaultName_,
         this.binding_.names,
         from,
@@ -267,7 +282,7 @@ export default class ImportNode extends Statement {
     const parts = [];
     if (this.defaultName_) parts.push(this.defaultName_);
     if (this.binding_?.type === 'namespace') parts.push(`* as ${this.binding_.alias}`);
-    return composeNodeAsParts(parts, from, extraLength, config);
+    return composeNodeAsParts(verb, parts, from, extraLength, config);
   }
 }
 
@@ -290,10 +305,10 @@ function isNameUsed(
 
 function getDefaultAndBinding(importClause: ImportClause | undefined) {
   if (!importClause) return { isScript: true };
-  const { name, namedBindings } = importClause;
+  const { name, namedBindings, isTypeOnly } = importClause;
   const defaultName = name && name.text;
   const binding = getBinding(namedBindings);
-  return { defaultName, binding, isScript: false };
+  return { defaultName, binding, isScript: false, isTypeOnly };
 }
 
 function getBinding(nb: NamedImportBindings | undefined): Binding | undefined {

--- a/src/format/parser/ImportNode.ts
+++ b/src/format/parser/ImportNode.ts
@@ -28,7 +28,7 @@ export default class ImportNode extends Statement {
 
   readonly moduleIdentifier: string;
   readonly isScript: boolean;
-  private readonly isTypeOnly_: boolean;
+  readonly isTypeOnly: boolean;
   private defaultName_?: string;
   private binding_?: Binding;
 
@@ -67,7 +67,7 @@ export default class ImportNode extends Statement {
     this.defaultName_ = defaultName;
     this.binding_ = binding;
     this.isScript = isScript;
-    this.isTypeOnly_ = isTypeOnly;
+    this.isTypeOnly = isTypeOnly;
   }
 
   get defaultName() {
@@ -118,18 +118,18 @@ export default class ImportNode extends Statement {
    *          false if `node` still has names or comments thus can't be ignored.
    */
   merge(node: ImportNode) {
-    const { isTypeOnly_: t } = this;
+    const { isTypeOnly } = this;
     if (
       this.moduleIdentifier !== node.moduleIdentifier ||
       this.node_.kind !== node.node_.kind ||
-      t !== node.isTypeOnly_ ||
+      isTypeOnly !== node.isTypeOnly ||
       !this.canMergeComments(node)
     )
       return false;
     this.removeBindingDefault(node.defaultName_);
     node.removeBindingDefault(this.defaultName_);
-    const r1 = this.mergeBinding(node, !t);
-    const r2 = this.mergeDefaultName(node, !t);
+    const r1 = this.mergeBinding(node, !isTypeOnly);
+    const r2 = this.mergeDefaultName(node, !isTypeOnly);
     return r1 && r2 && this.mergeComments(node);
   }
 
@@ -138,7 +138,7 @@ export default class ImportNode extends Statement {
     if (this.defaultName_) this.removeBindingDefault(this.defaultName_);
     // `import {default as A, B} from 'x'` => `import A, {B} from 'x'`
     // `import type {default as A} from 'x'` => `import type A from 'x'`
-    else this.defaultName_ = this.pickBindingDefault(this.isTypeOnly_);
+    else this.defaultName_ = this.pickBindingDefault(this.isTypeOnly);
   }
 
   compose(config: ComposeConfig) {
@@ -264,7 +264,7 @@ export default class ImportNode extends Statement {
     const path = this.moduleIdentifier;
     const ending = quote(path);
     if (this.isScript) return `import ${ending}`;
-    const verb = 'import' + (this.isTypeOnly_ ? ' type' : '');
+    const verb = 'import' + (this.isTypeOnly ? ' type' : '');
     const from = `from ${ending}`;
     if (this.binding_?.type === 'named')
       return composeNodeAsNames(

--- a/src/format/sort/compare.ts
+++ b/src/format/sort/compare.ts
@@ -48,11 +48,19 @@ export function compareNodes(
 ) {
   return (
     comparePaths(a.moduleIdentifier, b.moduleIdentifier) ||
+    compareTypeOnly(a.isTypeOnly, b.isTypeOnly) ||
     (compareNames
       ? compareDefaultName(a.defaultName, b.defaultName, compareNames) ||
         compareBinding(a.binding, b.binding, compareNames)
       : 0)
   );
+}
+
+/**
+ * Sort typed imports in front of other imports.
+ */
+function compareTypeOnly(a: boolean, b: boolean) {
+  return (a ? 0 : 1) - (b ? 0 : 1);
 }
 
 /**

--- a/src/format/sort/merge.ts
+++ b/src/format/sort/merge.ts
@@ -20,7 +20,7 @@ export function sortAndMergeImportNodes(
   );
   merged.forEach(n => {
     if (n.binding?.type !== 'named') return;
-    n.binding.names = mergeNames(n.binding.names, compareNames);
+    n.binding.names = sortAndDedupNames(n.binding.names, compareNames);
     n.checkBindingDefault();
   });
   return comparePaths
@@ -31,10 +31,13 @@ export function sortAndMergeImportNodes(
 export function sortAndMergeExportNodes(nodes: ExportNode[], compareNames?: Comparator) {
   nodes
     .reduce((r, n) => (r.some(a => a.merge(n)) ? r : [...r, n]), Array<ExportNode>())
-    .forEach(n => (n.names = mergeNames(n.names, compareNames)));
+    .forEach(n => (n.names = sortAndDedupNames(n.names, compareNames)));
 }
 
-function mergeNames(names: NameBinding[], compareNames?: Comparator) {
+/**
+ * Sort names and remove duplicates.
+ */
+function sortAndDedupNames(names: NameBinding[], compareNames?: Comparator) {
   return compareNames
     ? names
         .sort((a, b) => compareBindingName(a, b, compareNames))

--- a/src/test/suite/examples/compose/max-binding-names/type.origin.ts
+++ b/src/test/suite/examples/compose/max-binding-names/type.origin.ts
@@ -1,0 +1,6 @@
+import type {A,B,C} from 'a';
+import type{D, E, F, G}from 'b';
+
+export type {A,B}
+type X =C&D&E&F&G
+export type{AA, BB, CC} from 'a'

--- a/src/test/suite/examples/compose/max-binding-names/type.result.ts
+++ b/src/test/suite/examples/compose/max-binding-names/type.result.ts
@@ -1,0 +1,15 @@
+import type { A, B, C } from 'a';
+import type {
+  D,
+  E,
+  F,
+  G,
+} from 'b';
+
+export type { A, B };
+type X =C&D&E&F&G
+export type {
+  AA,
+  BB,
+  CC,
+} from 'a';

--- a/src/test/suite/examples/compose/max-line-length/origin.ts
+++ b/src/test/suite/examples/compose/max-line-length/origin.ts
@@ -4,10 +4,14 @@ import 'aaaaaaaaaaaaaaaaaaaaa';
 import AAA from 'aaaaaaaaaaa';
 import AA from 'aaaaaaaaaaaaa';
 import A from 'aa';   //comment
+import type AAAA from 'aaaaa';
+import type AAAA from 'aaaaaa';
 
 import { BBB } from 'bbbbbbb';
 import { BB } from 'bbbbbbbbb';
 import { B } from 'bb';//commnt
+import type { BBBB } from 'b';
+import type { BBBB } from 'bb';
 
 import CCC = require('ccccc');
 import CC = require('ccccccc');
@@ -22,6 +26,8 @@ export { aaaaa, bbb } from 'a';
 export { aaaa } from 'a'; //cmt
 export { a, b } from 'a';/*cmt
 xxx*/
+export type { a, b } from 'a';
+export type { a, b } from 'aa';
 
 
-type X = C&CC&CCC&BB& D&DD&DDD;
+type X = C & CC & CCC & BB & D & DD & DDD & AAAA & BBBB;

--- a/src/test/suite/examples/compose/max-line-length/result.ts
+++ b/src/test/suite/examples/compose/max-line-length/result.ts
@@ -3,12 +3,19 @@ import 'aaaaaaaaaaaaaaaaaaaaa';
 
 import A
   from 'aa';   //comment
+import type AAAA from 'aaaaa';
+import type AAAA
+  from 'aaaaaa';
 import AAA from 'aaaaaaaaaaa';
 import AA
   from 'aaaaaaaaaaaaa';
+import type { BBBB } from 'b';
 import {
   B,
 } from 'bb';//commnt
+import type {
+  BBBB,
+} from 'bb';
 import { BBB } from 'bbbbbbb';
 import {
   BB,
@@ -32,5 +39,10 @@ export {
 } from 'a'; //cmt
 export { a, b } from 'a';/*cmt
 xxx*/
+export type { a, b } from 'a';
+export type {
+  a,
+  b,
+} from 'aa';
 
-type X = C&CC&CCC&BB& D&DD&DDD;
+type X = C & CC & CCC & BB & D & DD & DDD & AAAA & BBBB;

--- a/src/test/suite/examples/compose/max-line-length/result.ts
+++ b/src/test/suite/examples/compose/max-line-length/result.ts
@@ -10,12 +10,12 @@ import AAA from 'aaaaaaaaaaa';
 import AA
   from 'aaaaaaaaaaaaa';
 import type { BBBB } from 'b';
-import {
-  B,
-} from 'bb';//commnt
 import type {
   BBBB,
 } from 'bb';
+import {
+  B,
+} from 'bb';//commnt
 import { BBB } from 'bbbbbbb';
 import {
   BB,

--- a/src/test/suite/examples/duplicate/type.origin.ts
+++ b/src/test/suite/examples/duplicate/type.origin.ts
@@ -1,0 +1,9 @@
+import type {A, A, D as E, D as E} from 'a'
+import type {A, D as E}from 'a'
+
+import type B from 'b'
+import type B from 'b'
+
+
+export type {A, A, B, C,  E as D, E as D}
+export type {A, E as D}

--- a/src/test/suite/examples/duplicate/type.result.ts
+++ b/src/test/suite/examples/duplicate/type.result.ts
@@ -1,0 +1,7 @@
+import type {
+  A,
+  D as E,
+} from 'a';
+import type B from 'b';
+
+export type { A, B, C, E as D };

--- a/src/test/suite/examples/merge/export/type.origin.ts
+++ b/src/test/suite/examples/merge/export/type.origin.ts
@@ -1,0 +1,17 @@
+export {A}
+export type {B}
+export type {C}
+
+import type A from 'a'
+import type {B} from 'a'
+import * as D from 'a'
+import type {C} from 'a'
+import {E}from 'a'
+import F from 'a'
+import type A from 'a'
+
+import type {default as G} from 'a'
+import type {default as H} from 'b'
+
+export {D, E,F, G}
+export type  {H} 

--- a/src/test/suite/examples/merge/export/type.result.ts
+++ b/src/test/suite/examples/merge/export/type.result.ts
@@ -1,6 +1,6 @@
 import type A from 'a';
-import F, * as D from 'a';
 import type { default as G, B, C } from 'a';
+import F, * as D from 'a';
 import { E } from 'a';
 import type H from 'b';
 

--- a/src/test/suite/examples/merge/export/type.result.ts
+++ b/src/test/suite/examples/merge/export/type.result.ts
@@ -1,0 +1,8 @@
+import type A from 'a';
+import F, * as D from 'a';
+import type { default as G, B, C } from 'a';
+import { E } from 'a';
+import type H from 'b';
+
+export { A, D, E, F, G };
+export type { B, C, H };

--- a/src/test/suite/examples/others/type-only.origin.ts
+++ b/src/test/suite/examples/others/type-only.origin.ts
@@ -1,0 +1,4 @@
+import type A from 'A'
+import type { B } from 'B'
+
+export type { A, B }

--- a/src/test/suite/examples/others/type-only.origin.ts
+++ b/src/test/suite/examples/others/type-only.origin.ts
@@ -1,4 +1,0 @@
-import type A from 'a'
-import type { B } from 'b'
-
-export type { A, B }

--- a/src/test/suite/examples/others/type-only.origin.ts
+++ b/src/test/suite/examples/others/type-only.origin.ts
@@ -1,4 +1,4 @@
-import type A from 'A'
-import type { B } from 'B'
+import type A from 'a'
+import type { B } from 'b'
 
 export type { A, B }

--- a/src/test/suite/examples/others/type.origin.ts
+++ b/src/test/suite/examples/others/type.origin.ts
@@ -1,0 +1,4 @@
+import type A from 'a';
+import type { B } from 'b';
+
+export type { A, B };

--- a/src/test/suite/examples/sort/type.origin.ts
+++ b/src/test/suite/examples/sort/type.origin.ts
@@ -1,0 +1,7 @@
+import type { A } from 'a';
+import B, * as E from 'a';
+import type C from 'a';
+import { D } from 'a'
+
+
+export  { A, B, C, D, E };

--- a/src/test/suite/examples/sort/type.result.ts
+++ b/src/test/suite/examples/sort/type.result.ts
@@ -1,0 +1,6 @@
+import type C from 'a';
+import type { A } from 'a';
+import B, * as E from 'a';
+import { D } from 'a';
+
+export  { A, B, C, D, E };


### PR DESCRIPTION
Initial work to fix #14, for now only a failing test.

I tried to have a look through AST how to identify `type` only import/export, but I am not seeing it in there.

https://astexplorer.net/#/gist/055e51ba88b48bc2ec5f89d7aa179240/921c3267c5b3d27edc75531a081dedbcc75274ba